### PR TITLE
Add eslint config for the sample app and improve the readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,6 @@
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/wso2/product-is/blob/master/LICENSE)
 [![Twitter](https://img.shields.io/twitter/follow/wso2.svg?style=social&label=Follow)](https://twitter.com/intent/follow?screen_name=wso2)
 
-🚧 &ensp;&ensp;This project is a work in progress. Please do not use this yet!
-
 ## Table of Content
 
 - [Introduction](#introduction)
@@ -75,7 +73,7 @@ const { AsgardeoAuth } = require('@asgardeo/auth-nodejs-sdk');
 const config = {
     clientID: "<your_client_id>",
     clientSecret: "<your_client_secret>",
-    serverOrigin: "https://api.asgardeo.io/t/<org_name>",
+    baseUrl: "https://api.asgardeo.io/t/<org_name>",
     signInRedirectURL: "http://localhost:3000/auth/login",
     signOutRedirectURL: "http://localhost:3000",
     scope: ["openid", "profile"]
@@ -90,7 +88,7 @@ app.use(cookieParser());
 const authClient = new AsgardeoAuth(config);
 
 // Implement a login route.
-// For this example, we will define the login route as '/auth/sign-in'. 
+// For this example, we will define the login route as '/auth/sign-in'.
 // You can change this to match your use case.
 app.get("/auth/sign-in", (req, res) => {
 
@@ -99,7 +97,7 @@ app.get("/auth/sign-in", (req, res) => {
 
     // If the user ID is not present, create a new user ID.
     if (!userID) {
-        userID = uuidv4(); 
+        userID = uuidv4();
     }
 
     // Define the callback function of the 'signIn' method
@@ -156,7 +154,7 @@ new AsgardeoAuth(config:AuthClientConfig<T>, store?: Store);
 
 1. config: [`AuthClientConfig<T>`](#AuthClientConfigT)
 
-   This contains the configuration information needed to implement authentication such as the client ID, server origin etc. Additional configuration information that is needed to be stored can be passed by extending the type of this argument using the generic type parameter. For example, if you want the config to have an attribute called `foo`, you can create an interface called `Bar` in TypeScript and then pass that interface as the generic type to `AuthClientConfig` interface. To learn more about what attributes can be passed into this object, refer to the [`AuthClientConfig<T>`](#AuthClientConfigT) section.
+   This contains the configuration information needed to implement authentication such as the client ID, base URL etc. Additional configuration information that is needed to be stored can be passed by extending the type of this argument using the generic type parameter. For example, if you want the config to have an attribute called `foo`, you can create an interface called `Bar` in TypeScript and then pass that interface as the generic type to `AuthClientConfig` interface. To learn more about what attributes can be passed into this object, refer to the [`AuthClientConfig<T>`](#AuthClientConfigT) section.
 
    ```TypeScript
    interface Bar {
@@ -174,7 +172,7 @@ new AsgardeoAuth(config:AuthClientConfig<T>, store?: Store);
        signInRedirectURL: "http://localhost:3000/sign-in",
        signOutRedirectURL: "http://localhost:3000/login",
        clientID: "client ID",
-       serverOrigin: "https://api.asgardeo.io/t/<org_name>"
+       baseUrl: "https://api.asgardeo.io/t/<org_name>"
    };
    ```
 
@@ -663,7 +661,7 @@ This model has the following attributes.
 |`prompt`|Optional| `string`|""|Specifies the prompt type of an OIDC request|
 |`responseMode`|Optional| `ResponseMode`|`"query"`|Specifies the response mode. The value can either be `query` or `form_post`|
 |`scope`|Optional| `string[]`|`["openid"]`|Specifies the requested scopes.|
-|`serverOrigin`|Required| `string`|""|The origin of the Identity Provider. eg: `https://api.asgardeo.io/t/<org_name>`|
+|`baseUrl`|Required| `string`|""|The origin of the Identity Provider. eg: `https://api.asgardeo.io/t/<org_name>`|
 |`endpoints`|Optional| `OIDCEndpoints`|[OIDC Endpoints Default Values](#oidc-endpoints)|The OIDC endpoint URLs. The SDK will try to obtain the endpoint URLS |using the `.well-known` endpoint. If this fails, the SDK will use these endpoint URLs. If this attribute is not set, then the default endpoint URLs will be |used. However, if the `overrideWellEndpointConfig` is set to `true`, then this will override the endpoints obtained from the `.well-known` endpoint. |
 |`overrideWellEndpointConfig`|Optional| `boolean` | `false` | If this option is set to `true`, then the `endpoints` object will override endpoints obtained |from the `.well-known` endpoint. If this is set to `false`, then this will be used as a fallback if the request to the `.well-known` endpoint fails.|
 |`wellKnownEndpoint`|Optional| `string`|`"/oauth2/token/.well-known/openid-configuration"`| The URL of the `.well-known` endpoint.|

--- a/samples/asgardeo-express-app/.eslintignore
+++ b/samples/asgardeo-express-app/.eslintignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+umd/

--- a/samples/asgardeo-express-app/.eslintignore
+++ b/samples/asgardeo-express-app/.eslintignore
@@ -1,3 +1,1 @@
 node_modules/
-dist/
-umd/

--- a/samples/asgardeo-express-app/.eslintrc.js
+++ b/samples/asgardeo-express-app/.eslintrc.js
@@ -1,0 +1,75 @@
+module.exports = {
+    env: {
+        browser: true,
+        es6: true,
+        jest: true,
+        node: true
+    },
+    extends: [ "eslint:recommended", "plugin:import/typescript" ],
+    overrides: [ {
+        env: {
+            browser: true,
+            es6: true,
+            node: true
+        },
+        extends: [
+            "eslint:recommended",
+            "plugin:@typescript-eslint/eslint-recommended",
+            "plugin:@typescript-eslint/recommended"
+        ],
+        files: [ "**/*.ts" ],
+        parser: "@typescript-eslint/parser",
+        parserOptions: {
+            ecmaVersion: 9,
+            sourceType: "module"
+        },
+        rules: {
+            "@typescript-eslint/explicit-function-return-type": 0,
+            "@typescript-eslint/no-explicit-any": 0,
+            "@typescript-eslint/no-inferrable-types": "off",
+            "@typescript-eslint/no-unused-vars": "off",
+            "@typescript-eslint/no-use-before-define": [ "warn", {
+                classes: false,
+                functions: false,
+                typedefs: false,
+                variables: false
+            } ],
+            "eol-last": "error",
+            "no-debugger": "warn",
+            "no-use-before-define": "off"
+        }
+    } ],
+    parserOptions: {
+        ecmaVersion: 9,
+        sourceType: "module"
+    },
+    plugins: [ "import" ],
+    rules: {
+        "comma-dangle": [ "warn", "never" ],
+        "eol-last": "error",
+        "import/order": [ "warn", {
+            "alphabetize": {
+                caseInsensitive: true,
+                order: "asc"
+            },
+            "groups": [ "builtin", "external", "index", "sibling", "parent", "internal" ]
+        } ],
+        "max-len": [ "warn", {
+            "code": 120
+        } ],
+        "no-console": "warn",
+        "no-duplicate-imports": "warn",
+        "object-curly-spacing": [ "warn", "always" ],
+        "quotes": [ "warn", "double" ],
+        "sort-imports": [ "warn", {
+            "ignoreCase": false,
+            "ignoreDeclarationSort": true,
+            "ignoreMemberSort": false
+        } ],
+        "sort-keys": [ "warn", "asc", {
+            "caseSensitive": true,
+            "minKeys": 2,
+            "natural": false
+        } ]
+    }
+};

--- a/samples/asgardeo-express-app/config.json
+++ b/samples/asgardeo-express-app/config.json
@@ -1,7 +1,7 @@
 {
   "clientID": "",
   "clientSecret": "",
-  "serverOrigin": "",
+  "baseUrl": "",
   "signInRedirectURL": "http://localhost:3000/auth/login",
   "signOutRedirectURL": "http://localhost:3000",
   "scope": ["openid", "profile"]

--- a/samples/asgardeo-express-app/index.js
+++ b/samples/asgardeo-express-app/index.js
@@ -99,7 +99,6 @@ app.get("/auth/login", (req, res) => {
                 res.redirect("/");
             }
         }).catch((err) => {
-            console.log(err)
             res.redirect("/?error=true");
         })
 });

--- a/samples/asgardeo-express-app/index.js
+++ b/samples/asgardeo-express-app/index.js
@@ -16,16 +16,16 @@
  * under the License.
  */
 
-const express = require("express");
-const cookieParser = require("cookie-parser");
 const { AsgardeoNodeClient } = require("@asgardeo/auth-node-sdk");
-const config = require("./config.json");
-const { v4: uuidv4 } = require("uuid");
+const cookieParser = require("cookie-parser");
+const express = require("express");
 const rateLimit = require("express-rate-limit");
+const { v4: uuidv4 } = require("uuid");
+const config = require("./config.json");
 
 const limiter = rateLimit({
-    windowMs: 1 * 60 * 1000, // 1 minute
-    max: 100
+    max: 100,
+    windowMs: 1 * 60 * 1000 // 1 minute
 });
 
 //Constants
@@ -45,11 +45,11 @@ app.use("/", express.static("static"));
 const authClient = new AsgardeoNodeClient(config);
 
 const dataTemplate = {
-    isConfigPresent: Boolean(config && config.clientID && config.clientSecret),
-    isAuthenticated: false,
-    idToken: null,
+    authenticateResponse: null,
     error: false,
-    authenticateResponse: null
+    idToken: null,
+    isAuthenticated: false,
+    isConfigPresent: Boolean(config && config.clientID && config.clientSecret)
 };
 
 //Routes
@@ -85,7 +85,11 @@ app.get("/auth/login", (req, res) => {
     const redirectCallback = (url) => {
         if (url) {
             // Make sure you use the httpOnly and sameSite to prevent from cross-site request forgery (CSRF) attacks.
-            res.cookie("ASGARDEO_SESSION_ID", userID, { maxAge: 900000, httpOnly: true, sameSite: "lax" });
+            res.cookie("ASGARDEO_SESSION_ID", userID, {
+                httpOnly: true,
+                maxAge: 900000,
+                sameSite: "lax"
+            });
             res.redirect(url);
 
             return;
@@ -98,9 +102,10 @@ app.get("/auth/login", (req, res) => {
             if (response.accessToken || response.idToken) {
                 res.redirect("/");
             }
-        }).catch((err) => {
-            res.redirect("/?error=true");
         })
+        .catch(() => {
+            res.redirect("/?error=true");
+        });
 });
 
 app.get("/auth/logout", (req, res) => {
@@ -122,5 +127,6 @@ app.get("/auth/logout", (req, res) => {
 
 //Start the app and listen on PORT 5000
 app.listen(PORT, () => {
+    // eslint-disable-next-line no-console
     console.log(`Server Started at PORT ${ PORT }`);
 });

--- a/samples/asgardeo-express-app/index.js
+++ b/samples/asgardeo-express-app/index.js
@@ -25,7 +25,7 @@ const rateLimit = require("express-rate-limit");
 
 const limiter = rateLimit({
     windowMs: 1 * 60 * 1000, // 1 minute
-    max: 5
+    max: 100
 });
 
 //Constants
@@ -99,6 +99,7 @@ app.get("/auth/login", (req, res) => {
                 res.redirect("/");
             }
         }).catch((err) => {
+            console.log(err)
             res.redirect("/?error=true");
         })
 });

--- a/samples/asgardeo-express-app/views/index.ejs
+++ b/samples/asgardeo-express-app/views/index.ejs
@@ -105,8 +105,7 @@
                                     Derived by the&nbsp;
                                     <code className="inline-code-block">
                                 <a href="https://www.npmjs.com/package/@asgardeo/auth-node/v/latest" target="_blank">
-                                    @asgardeo/auth-node
-                                </a> </code>&nbsp;SDK
+                                    @asgardeo/auth-node</a></code>&nbsp;SDK
                                 </h4>
                                 <div class="json">
                                     <div id="authentication-response" class="json-container"></div>


### PR DESCRIPTION
This PR
- Adds eslint config to the sample app
- Fix lint issues in the sample app
- Replaces `serverOrigin` with `baseUrl` 
- Removes WIP notice from the readme file