### PR TITLE
Add refreshAccessToken method to AsgardeoNodeClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@
   - [getOIDCServiceEndpoints](#getOIDCServiceEndpoints)
   - [getAccessToken](#getAccessToken)
   - [revokeAccessToken](#revokeAccessToken)
+  - [refreshAccessToken](#refreshAccessToken)
   - [requestCustomGrant](#requestCustomGrant)
   - [updateConfig](#updateConfig)
   - [isSignOutSuccessful](#isSignOutSuccessful)
@@ -485,6 +486,35 @@ This method clears the authentication data and sends a request to revoke the acc
 ```TypeScript
 // This should be within an async function.
 const revokeToken = await auth.revokeAccessToken("a2a2972c-51cd-5e9d-a9ae-058fae9f7927");
+```
+
+---
+
+### refreshAccessToken
+
+```TypeScript
+refreshAccessToken(userID?: string): Promise<TokenResponse>
+```
+
+#### Argument
+
+1. userID: `string` (optional)
+
+    If you want to use the SDK to manage multiple user sessions, you can pass a unique ID here. This can be useful when this SDK is used in backend applications.
+
+#### Returns
+
+A Promise that resolves with the token response that contains the token information.
+
+#### Description
+
+This method sends a refresh-token request and returns a promise that resolves with the token information. To learn more about what information is returned, checkout the [`TokenResponse`](#TokenResponse) model. The existing authentication data in the store is automatically updated with the new information returned by this request.
+
+#### Example
+
+```TypeScript
+// This should be within an async function.
+const tokenResponse = await auth.refreshAccessToken("a2a2972c-51cd-5e9d-a9ae-058fae9f7927")
 ```
 
 ---

--- a/lib/src/client.ts
+++ b/lib/src/client.ts
@@ -269,19 +269,19 @@ export class AsgardeoNodeClient<T> {
      *
      * @example
      * ```
-     *const config = {
+     * const config = {
      *      attachToken: false,
      *      data: {
      *          client_id: "{{clientID}}",
      *          grant_type: "account_switch",
      *          scope: "{{scope}}",
      *          token: "{{token}}",
-     *       },
+     *      },
      *      id: "account-switch",
      *      returnResponse: true,
      *      returnsSession: true,
      *      signInRequired: true
-     *   }
+     * }
 
      * auth.requestCustomGrant(config).then((response)=>{
      *     console.log(response);
@@ -332,7 +332,7 @@ export class AsgardeoNodeClient<T> {
      *
      * @example
      * ```
-     *const revokeToken = await auth.revokeAccessToken("a2a2972c-51cd-5e9d-a9ae-058fae9f7927");
+     * const revokeToken = await auth.revokeAccessToken("a2a2972c-51cd-5e9d-a9ae-058fae9f7927");
      * ```
      *
      * @link https://github.com/asgardeo/asgardeo-auth-js-sdk/tree/master#revokeAccessToken
@@ -342,6 +342,28 @@ export class AsgardeoNodeClient<T> {
      */
     public async revokeAccessToken(userId?: string): Promise<FetchResponse> {
         return this._authCore.revokeAccessToken(userId);
+    }
+
+    /**
+     * This method refreshes the access token and returns a Promise that resolves with the new access
+     * token and other relevant data.
+     *
+     * @param {string} userId - A unique ID of the user to be authenticated. This is useful in multi-user
+     * scenarios where each user should be uniquely identified.
+     *
+     * @returns {Promise<TokenResponse>} - A Promise that resolves with the token response.
+     *
+     * @example
+     * ```
+     * const tokenResponse = await auth.refreshAccessToken("a2a2972c-51cd-5e9d-a9ae-058fae9f7927")
+     * ```
+     *
+     * @link https://github.com/asgardeo/asgardeo-auth-js-sdk/tree/master#refreshAccessToken
+     *
+     * @memberof AsgardeoNodeClient
+     */
+    public refreshAccessToken(userId?: string): Promise<TokenResponse> {
+        return this._authCore.refreshAccessToken(userId);
     }
 
     /**

--- a/lib/src/core/authentication.ts
+++ b/lib/src/core/authentication.ts
@@ -168,7 +168,7 @@ export class AsgardeoNodeCore<T> {
         }
     }
 
-    public async refreshAccessToken(userId: string): Promise<TokenResponse> {
+    public async refreshAccessToken(userId?: string): Promise<TokenResponse> {
         return this._auth.refreshAccessToken(userId);
     }
 


### PR DESCRIPTION
- adds the missing `refreshAccessToken` method to the `AsgardeoNodeClient` class
- makes `userId` an optional parameter for the `refreshAccessToken` method
- updates the `README.md` and addds JSDoc for `refreshAccessToken`

Fixes https://github.com/asgardeo/asgardeo-auth-node-sdk/issues/26

Most of the implementation was copied over from [asgardeo-auth-js-core](https://github.com/asgardeo/asgardeo-auth-js-core).